### PR TITLE
apply project configuration to project parameters

### DIFF
--- a/SSIS2012Tasks/DeploymentFileCompilerTask.cs
+++ b/SSIS2012Tasks/DeploymentFileCompilerTask.cs
@@ -192,6 +192,8 @@ namespace Microsoft.SqlServer.IntegrationServices.Build
 							if (Guid.TryParse(key, out guid))
 							{
 								var setting = ProjectConfiguration.Options.ParameterConfigurationValues[key];
+								Log.LogMessage("Setting conf value: " + setting.Name.Replace("Project::", "") + " = " + setting.Value);
+								project.Parameters[setting.Name.Replace("Project::", "")].Value = setting.Value;
 								parameterSet.Add(key, setting);
 							}
 						}


### PR DESCRIPTION
Hi,

it took me quiet some research to figure out why the project level connection strings of my project were lost on deployment with msbuild.
Visual Studio applies them just fine.

Fix that.

Thanks for hosting this tool!

regards
Felix