### PR TITLE
Add Description to the manifest

### DIFF
--- a/SSIS2012Tasks/DeploymentFileCompilerTask.cs
+++ b/SSIS2012Tasks/DeploymentFileCompilerTask.cs
@@ -364,6 +364,9 @@ namespace Microsoft.SqlServer.IntegrationServices.Build
 					case "VersionComments":
 						project.VersionComments = manifest.Properties[prop];
 						break;
+					case "Description":
+						project.Description = manifest.Properties[prop];
+						break;
 				}
 			}
 		}


### PR DESCRIPTION
Add the description to make it show up in the SSIS catalog. Otherwise all information written there before build gets lost.